### PR TITLE
Use @nodesecure/github instead of the old @slimio one

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,9 +10,9 @@
       "license": "MIT",
       "dependencies": {
         "@myunisoft/httpie": "^1.8.0",
+        "@nodesecure/github": "^1.1.0",
         "@nodesecure/npm-registry-sdk": "^1.4.0",
         "@npmcli/arborist": "^5.3.0",
-        "@slimio/github": "^1.0.0",
         "semver": "^7.3.7"
       },
       "devDependencies": {
@@ -573,6 +573,18 @@
         "eslint": "^8.17.0"
       }
     },
+    "node_modules/@nodesecure/github": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@nodesecure/github/-/github-1.1.0.tgz",
+      "integrity": "sha512-BNNY4X9bvkPdsmkn2VTYsfslJEeFoHR9otDln0yacWGwm5UkVyU2vuyYLanhCvUSVKQYdSPlZyCxtO93NEtqCg==",
+      "dependencies": {
+        "@myunisoft/httpie": "^1.8.0",
+        "tar-fs": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/@nodesecure/npm-registry-sdk": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/@nodesecure/npm-registry-sdk/-/npm-registry-sdk-1.4.0.tgz",
@@ -815,23 +827,11 @@
         "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
     },
-    "node_modules/@slimio/github": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@slimio/github/-/github-1.0.0.tgz",
-      "integrity": "sha512-HjH/KeJszTKrL8tL106l4NwmDDh6jlZ7ZcTTzZXuX4aU3pBNGScYouT4CoxUu83z8KvkZWa6BgPy4c32KpvBaw==",
-      "dependencies": {
-        "@myunisoft/httpie": "^1.0.0",
-        "@slimio/is": "^1.5.0",
-        "tar-fs": "^2.1.1"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "node_modules/@slimio/is": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/@slimio/is/-/is-1.5.1.tgz",
       "integrity": "sha512-xQ0AgodIE8nHYy508AVmpxqnIr/Ytyz5Xm7I6NQU33+RvDzs94T9c0dTnUWuariByLr1geXXe6kMaTM9TcOIEA==",
+      "dev": true,
       "engines": {
         "node": ">=10"
       }
@@ -6622,6 +6622,15 @@
         "eslint": "^8.17.0"
       }
     },
+    "@nodesecure/github": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@nodesecure/github/-/github-1.1.0.tgz",
+      "integrity": "sha512-BNNY4X9bvkPdsmkn2VTYsfslJEeFoHR9otDln0yacWGwm5UkVyU2vuyYLanhCvUSVKQYdSPlZyCxtO93NEtqCg==",
+      "requires": {
+        "@myunisoft/httpie": "^1.8.0",
+        "tar-fs": "^2.1.1"
+      }
+    },
     "@nodesecure/npm-registry-sdk": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/@nodesecure/npm-registry-sdk/-/npm-registry-sdk-1.4.0.tgz",
@@ -6817,20 +6826,11 @@
         "which": "^2.0.2"
       }
     },
-    "@slimio/github": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@slimio/github/-/github-1.0.0.tgz",
-      "integrity": "sha512-HjH/KeJszTKrL8tL106l4NwmDDh6jlZ7ZcTTzZXuX4aU3pBNGScYouT4CoxUu83z8KvkZWa6BgPy4c32KpvBaw==",
-      "requires": {
-        "@myunisoft/httpie": "^1.0.0",
-        "@slimio/is": "^1.5.0",
-        "tar-fs": "^2.1.1"
-      }
-    },
     "@slimio/is": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/@slimio/is/-/is-1.5.1.tgz",
-      "integrity": "sha512-xQ0AgodIE8nHYy508AVmpxqnIr/Ytyz5Xm7I6NQU33+RvDzs94T9c0dTnUWuariByLr1geXXe6kMaTM9TcOIEA=="
+      "integrity": "sha512-xQ0AgodIE8nHYy508AVmpxqnIr/Ytyz5Xm7I6NQU33+RvDzs94T9c0dTnUWuariByLr1geXXe6kMaTM9TcOIEA==",
+      "dev": true
     },
     "@small-tech/esm-tape-runner": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -55,9 +55,9 @@
   "type": "module",
   "dependencies": {
     "@myunisoft/httpie": "^1.8.0",
+    "@nodesecure/github": "^1.1.0",
     "@nodesecure/npm-registry-sdk": "^1.4.0",
     "@npmcli/arborist": "^5.3.0",
-    "@slimio/github": "^1.0.0",
     "semver": "^7.3.7"
   },
   "tsd": {

--- a/src/strategies/security-wg.js
+++ b/src/strategies/security-wg.js
@@ -3,7 +3,7 @@ import path from "path";
 import { unlinkSync, promises as fs } from "fs";
 
 // Import Third-party Dependencies
-import download from "@slimio/github";
+import { downloadAndExtract } from "@nodesecure/github";
 import semver from "semver";
 
 // Import Internal Dependencies
@@ -77,7 +77,7 @@ async function hydratePayloadDependencies(dependencies, options = {}) {
 }
 
 async function hydrateDatabase() {
-  const location = await download("nodejs.security-wg", { extract: true, branch: "main" });
+  const { location } = await downloadAndExtract("nodejs.security-wg", { branch: "main" });
   const vulnPath = path.join(location, "vuln", "npm");
 
   try {

--- a/test/strategies/integration/npm_audit.js
+++ b/test/strategies/integration/npm_audit.js
@@ -78,7 +78,7 @@ test("npm strategy: hydratePayloadDependencies using NodeSecure standard format"
 test("npm strategy: getVulnerabilities in NPM format", async(tape) => {
   const { getVulnerabilities } = NPMAuditStrategy();
   const vulnerabilities = await getVulnerabilities(path.join(kFixturesDir, "audit"));
-  tape.equal(Object.values(vulnerabilities).length, 17);
+  tape.equal(Object.values(vulnerabilities).length, 18);
 
   tape.end();
 });
@@ -87,14 +87,14 @@ test("npm strategy: getVulnerabilities in the standard NodeSecure format", async
   const { getVulnerabilities } = NPMAuditStrategy();
   const vulnerabilities = await getVulnerabilities(path.join(kFixturesDir, "audit"), { useStandardFormat: true });
 
-  tape.equal(vulnerabilities.length, 17);
+  tape.equal(vulnerabilities.length, 18);
   tape.deepEqual(vulnerabilities[0], {
     id: undefined,
     origin: "npm",
     package: "@npmcli/arborist",
     title: undefined,
     url: undefined,
-    severity: "medium",
+    severity: "high",
     vulnerableRanges: ["<=2.8.1"],
     vulnerableVersions: []
   });


### PR DESCRIPTION
This PR migrate to the new `@nodesecure/github` package to fetch the Node.js Security DB.

Also include a fix for NPM Audit integration test.